### PR TITLE
Enable using the security token for websocket connections

### DIFF
--- a/mocks/index.js
+++ b/mocks/index.js
@@ -39,10 +39,12 @@ httpService
     }
 
     // respond to client
-    ws.send(JSON.stringify({
-      type: "message",
-      msg: `myne:${recipient}:mocked server has recevied "${body}" message`
-    }));
+    ws.send(
+      JSON.stringify({
+        type: "message",
+        msg: `myne:${recipient}:mocked server has recevied "${body}" message`,
+      })
+    );
   });
 
 http.createServer(httpService).listen(HTTP_PORT, "localhost", () => {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "grommet": "^2.19.1",
     "grommet-icons": "^4.7.0",
     "immer": "^9.0.7",
-    "js-cookie": "^3.0.1",
     "lodash": "^4.17.21",
     "next": "12.0.4",
     "react": "17.0.2",

--- a/src/state/websocket.ts
+++ b/src/state/websocket.ts
@@ -6,7 +6,6 @@ import type { Settings } from ".";
 import { useEffect, useRef, useState } from "react";
 import { useImmer } from "use-immer";
 import { debounce } from "lodash";
-import cookies from "js-cookie";
 import { isSSR } from "../utils";
 
 export type ConnectionStatus = "CONNECTED" | "DISCONNECTED";
@@ -61,18 +60,13 @@ const useWebsocket = (settings: Settings) => {
       socketRef.current.close(1000, "Shutting down");
     }
 
-    // need to set the token in the cookie, to enable websocket authentication
+    // need to set the token in the query parameters, to enable websocket authentication
+    const wsUrl = new URL(settings.wsEndpoint);
     if (settings.securityToken) {
-      cookies.set("X-Auth-Token", settings.securityToken, {
-        path: "/",
-      });
-    } else {
-      cookies.remove("X-Auth-Token", {
-        path: "/",
-      });
+      wsUrl.search = `?apiToken=${settings.securityToken}`;
     }
     console.info("WS Connecting..");
-    socketRef.current = new WebSocket(settings.wsEndpoint);
+    socketRef.current = new WebSocket(wsUrl);
 
     // handle connection opening
     socketRef.current.addEventListener("open", handleOpenEvent);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,11 +2190,6 @@ jest-worker@27.0.0-next.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-js-cookie@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
-  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
We need to use the query parameters instead of cookies to make the
authentication work.