### PR TITLE
Blocked actions until successful connection

### DIFF
--- a/src/components/conversations-panel.tsx
+++ b/src/components/conversations-panel.tsx
@@ -69,6 +69,7 @@ const ConversationsPanel: FunctionComponent<{
               pad="small"
               alignSelf="end"
               round
+              disabled={status === 'DISCONNECTED'}
               onClick={() => setShowAnalytics(true)}
             >
               <BarChart color="light-1" />
@@ -79,6 +80,7 @@ const ConversationsPanel: FunctionComponent<{
               pad="small"
               alignSelf="end"
               round
+              disabled={status === 'DISCONNECTED'}
               onClick={() => setShowAddNewConv(true)}
             >
               <Add color="light-1" />

--- a/src/components/icon-button.tsx
+++ b/src/components/icon-button.tsx
@@ -3,9 +3,12 @@ import styled from "styled-components";
 import { Box, Button } from "grommet";
 import { normalizeColor } from "grommet/utils";
 
+const StyledButton = styled(Button)`
+  cursor: ${(props) => !props.disabled && 'pointer'};
+`
+
 const StyledBox = styled(Box)`
   display: inline-flex;
-  cursor: pointer;
   max-height: min-content;
   max-width: min-content;
 
@@ -30,7 +33,7 @@ const StyledBox = styled(Box)`
 // TODO: add types
 const IconButton: FunctionComponent<any> = (props) => {
   return (
-    <Button {...props}>
+    <StyledButton {...props}>
       <StyledBox
         pad="small"
         alignSelf="end"
@@ -40,7 +43,7 @@ const IconButton: FunctionComponent<any> = (props) => {
       >
         {props.children}
       </StyledBox>
-    </Button>
+    </StyledButton>
   );
 };
 


### PR DESCRIPTION
Merge #56 first.

- Ensured no actions can be done until a connection has been made successfully to a node.
- Reused the `status` pattern from the logo component, ensure `cursor` reflected these differences.
- Fixes #55