### PR TITLE
Manual deployment to Vercel via GH to support `v16`

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflows/vercel.yaml
+++ b/.github/ISSUE_TEMPLATE/workflows/vercel.yaml
@@ -1,0 +1,55 @@
+name: Deploy to Vercel
+
+on: [ push ]
+
+jobs:
+  deploy:
+    name: Deploying Mynechat
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [16]
+        os: ['ubuntu-latest']
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.7.0
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org/
+          cache: yarn
+
+       - name: Install dependencies
+        run: yarn
+
+      - name: Build
+        run: yarn build
+
+      - name: Deploy Preview
+        uses: amondnet/vercel-action@v20
+        id: vercel-deploy-preview
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_MYNE_CHAT_APP_PROJECT_ID }}
+          working-directory: .
+
+      - name: Deploy Production
+        uses: amondnet/vercel-action@v20
+        id: vercel-deploy-production
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_MYNE_CHAT_APP_PROJECT_ID }}
+          working-directory: .
+          vercel-args: "--prod"


### PR DESCRIPTION
Since Vercel only supports (at the time of this commit) up to v14, we cant use a series of
dependencies we have in @hoprnet available only v15> (e.g. new `peer-id@0.16.0`, see
hoprnet/hoprnet#3244)

Fixes #81