### PR TITLE
Patch verification by proper state management via propagated global handler

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,6 +15,7 @@ const HomePage: NextPage = () => {
     getReqHeaders,
     socketRef,
     setSelection,
+    setVerified,
     addNewConversation,
     addSentMessage,
     addReceivedMessage,
@@ -169,6 +170,8 @@ const HomePage: NextPage = () => {
           />
         ) : null}
         <Chat
+          setVerified={setVerified}
+          verified={verified}
           selection={selection}
           messages={conversation ? Array.from(conversation.values()) : []}
           sendMessage={handleSendMessage}

--- a/src/components/chat-input.tsx
+++ b/src/components/chat-input.tsx
@@ -1,16 +1,15 @@
 import type { FunctionComponent, KeyboardEvent } from "react";
 import { useState, useContext } from "react";
 import { Box, Button, TextArea, ResponsiveContext, CheckBox, Tip } from "grommet";
-import useAppState from "../state";
 
 const ChatInput: FunctionComponent<{
   sendMessage: (destination: string, message: string) => void;
   selection?: string;
-}> = ({ sendMessage, selection }) => {
+  setVerified: (verified: boolean) => void;
+  verified: boolean
+}> = ({ sendMessage, selection, setVerified, verified }) => {
   const screenSize = useContext(ResponsiveContext);
   const [content, setMessage] = useState<string>("");
-  const { setVerified, state } = useAppState()
-  const { verified } = state;
   const direction = screenSize === "small" ? "column" : "row";
   const disableInput = !selection;
   const disableSend = !selection || content.length === 0;

--- a/src/components/chat.tsx
+++ b/src/components/chat.tsx
@@ -10,7 +10,9 @@ const Chat: FunctionComponent<{
   sendMessage: (destination: string, message: string) => void;
   messages: Message[];
   selection?: string;
-}> = ({ selection, messages, sendMessage }) => {
+  setVerified: (verified: boolean) => void;
+  verified: boolean
+}> = ({ selection, messages, sendMessage, setVerified, verified }) => {
   return (
     <Box fill justify="between" background="dark-4" round shadow>
       {selection ? (
@@ -49,7 +51,12 @@ const Chat: FunctionComponent<{
             min: "min-content",
           }}
         >
-          <ChatInput sendMessage={sendMessage} selection={selection} />
+          <ChatInput
+            sendMessage={sendMessage}
+            selection={selection}
+            setVerified={setVerified}
+            verified={verified}
+          />
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
Since the App state isn't controlled via a Context-like wrapper as initially thought, all state modifiers need
to be propagated as props and components do not have scope to neither write nor read.

Fixes #89