### PR TITLE
Verify received message

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,6 +14,8 @@ import useUser from "../src/state/user";
 const HomePage: NextPage = () => {
   const {
     state: { selection, conversations, settings, verified },
+    addReceivedMessage,
+    addSentMessage,
     setSelection,
     setVerified,
     updateSettings,
@@ -47,11 +49,11 @@ const HomePage: NextPage = () => {
   // attach event listener for new messages
   useEffect(() => {
     if (!myPeerId || !socketRef.current) return;
-    socketRef.current.addEventListener("message", handleReceivedMessage);
+    socketRef.current.addEventListener("message", handleReceivedMessage(addReceivedMessage));
 
     return () => {
       if (!socketRef.current) return;
-      socketRef.current.removeEventListener("message", handleReceivedMessage);
+      socketRef.current.removeEventListener("message", handleReceivedMessage(addReceivedMessage));
     };
   }, [myPeerId, socketRef.current]);
 
@@ -108,7 +110,7 @@ const HomePage: NextPage = () => {
           verified={verified}
           selection={selection}
           messages={conversation ? Array.from(conversation.values()) : []}
-          sendMessage={handleSendMessage(myPeerId, socketRef, getReqHeaders(true))}
+          sendMessage={handleSendMessage(addSentMessage)(myPeerId, socketRef, getReqHeaders(true))}
         />
       </Box>
     </Box>

--- a/src/state/index.spec.ts
+++ b/src/state/index.spec.ts
@@ -68,5 +68,8 @@ describe('App State', () => {
     });
     expect(mockedSignRequest).toHaveBeenCalledWith(result.current.state.settings.httpEndpoint, headers);
     expect(mockedActualSignRequest).toHaveBeenCalledWith(originalMessage);
+    const actualMessageAfterEncoding = Utils.encodeMessage(myPeerId, originalMessage, signedMessage);
+    expect(mockedSendMessage).toHaveBeenCalledWith(result.current.state.settings.httpEndpoint, headers);
+    expect(mockedActualSendMessage).toHaveBeenCalledWith(recipientPeerId, actualMessageAfterEncoding, recipientPeerId, id, expect.any(Function));
   })
 })

--- a/src/state/index.spec.ts
+++ b/src/state/index.spec.ts
@@ -1,8 +1,10 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { act, renderHook } from '@testing-library/react-hooks'
 import { privKeyToPeerId, u8aToHex } from '@hoprnet/hopr-utils'
-import useAppState, { DEFAULT_SETTINGS } from '.'
+import useAppState, { DEFAULT_SETTINGS, UpdateMessageHandlerInterface } from '.'
 import { MutableRefObject } from 'react'
+import { enableMapSet } from "immer";
 import * as API from '../lib/api'
+import * as Utils from '../utils'
 
 
 describe('App State', () => {
@@ -11,20 +13,12 @@ describe('App State', () => {
   const privateKey = '0xcb1e5d91d46eb54a477a7eefec9c87a1575e3e5384d38f990f19c09aa8ddd332'
   const mockPeerId = privKeyToPeerId(privateKey)
   const myPeerId = mockPeerId.toB58String();
-  let mockedSignRequest;
+  let mockedSignRequest, mockedSendMessage;
 
   afterEach(() => {
     jest.resetAllMocks()
   })
-  test("init", async () => {
-    const signedMessage = u8aToHex(await mockPeerId.privKey.sign(
-      new TextEncoder().encode(originalMessage)
-    ))
-    mockedSignRequest = jest.spyOn(API, 'signRequest').mockImplementation(
-      (_endpoint: string, _headers: Headers) => (_encodeSignRequest: string): Promise<string> => {
-        return Promise.resolve(signedMessage);
-      });
-    // Finally, we actually call our hook with the mocked API, and verify the calls.
+  test("basic init state", async () => {
     const { result } = renderHook(() => useAppState())
     // No selection for the first `useEffect`
     expect(result.current.state.selection).toBeUndefined()
@@ -32,10 +26,47 @@ describe('App State', () => {
     expect(result.current.state.settings).toEqual(DEFAULT_SETTINGS)
     // Verified should be false
     expect(result.current.state.verified).toBeFalsy();
-    // This shouldn't call the method since `socketRef` is empty inside the WebSocket object.
-    result.current.handleSendMessage(myPeerId, {} as MutableRefObject<WebSocket | undefined>, {} as Headers)
-    // As we have mocked the `useUser` hook, we can spy on its calls.
-    expect(mockedSignRequest).not.toBeCalled();
+  })
 
+  test("handleSendMessage", async () => {
+    // We create a valid signed message to be used in our mocks.
+    const signedMessage = u8aToHex(await mockPeerId.privKey.sign(
+      new TextEncoder().encode(originalMessage)
+    ))
+    const id = Utils.genId();
+    const headers = {} as Headers;
+    const socketRef = jest.fn().mockImplementation(() => ({} as MutableRefObject<WebSocket | undefined>))() as MutableRefObject<WebSocket | undefined>;
+    const mockedActualSignRequest = jest.fn((_encodeSignRequest: string): Promise<string> => {
+      return Promise.resolve(signedMessage);
+    })
+    const mockedActualSendMessage = jest.fn((recipient: string, body: string, destination: string, id: string, updateMessage: UpdateMessageHandlerInterface): Promise<void> => {
+      return Promise.resolve();
+    })
+    mockedSignRequest = jest.spyOn(API, 'signRequest').mockImplementation((_endpoint: string, _headers: Headers) => mockedActualSignRequest);
+    mockedSendMessage = jest.spyOn(API, 'sendMessage').mockImplementation((_endpoint: string, _headers: Headers) => mockedActualSendMessage);
+    jest.spyOn(Utils, 'genId').mockReturnValue(id);
+
+    const { result } = renderHook(() => useAppState())
+    // This should immediately exit as websocket is empty, thus not calling our mock.
+    await act(() => result.current.handleSendMessage(myPeerId, {} as MutableRefObject<WebSocket | undefined>, headers)(recipientPeerId, originalMessage));
+    expect(mockedSignRequest).not.toHaveBeenCalled();
+
+    // Let's update verified/selection so we can enter the verified method.
+    act(() => {
+      result.current.setVerified(true)
+      result.current.setSelection(recipientPeerId)
+    })
+    expect(result.current.state.verified).toBeTruthy();
+    expect(result.current.state.selection).toEqual(recipientPeerId);
+    // Let's mock `socketRef.current` to enter in the actual method
+    socketRef.current = {} as WebSocket;
+
+    // Let's test the actual method
+    await act(async () => {
+      enableMapSet(); // Required by useImmer as we use maps
+      await result.current.handleSendMessage(myPeerId, socketRef, headers)(recipientPeerId, originalMessage)
+    });
+    expect(mockedSignRequest).toHaveBeenCalledWith(result.current.state.settings.httpEndpoint, headers);
+    expect(mockedActualSignRequest).toHaveBeenCalledWith(originalMessage);
   })
 })

--- a/src/state/index.spec.ts
+++ b/src/state/index.spec.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks'
 import { privKeyToPeerId, u8aToHex } from '@hoprnet/hopr-utils'
-import useAppState from '.'
+import useAppState, { DEFAULT_SETTINGS } from '.'
 import { MutableRefObject } from 'react'
 import * as API from '../lib/api'
 
@@ -26,9 +26,16 @@ describe('App State', () => {
       });
     // Finally, we actually call our hook with the mocked API, and verify the calls.
     const { result } = renderHook(() => useAppState())
-
+    // No selection for the first `useEffect`
+    expect(result.current.state.selection).toBeUndefined()
+    // Settings should be the default ones
+    expect(result.current.state.settings).toEqual(DEFAULT_SETTINGS)
+    // Verified should be false
+    expect(result.current.state.verified).toBeFalsy();
+    // This shouldn't call the method since `socketRef` is empty inside the WebSocket object.
     result.current.handleSendMessage(myPeerId, {} as MutableRefObject<WebSocket | undefined>, {} as Headers)
     // As we have mocked the `useUser` hook, we can spy on its calls.
     expect(mockedSignRequest).not.toBeCalled();
+
   })
 })

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -89,9 +89,9 @@ const useAppState = () => {
     myPeerId: string,
     destination: string,
     content: string,
+    id: string,
     verifiedStatus?: VerifiedStatus
   ) => {
-    const id = genId();
     setState((draft) => {
       const messages = draft.conversations.get(destination) || new Map<string, Message>();
 
@@ -110,8 +110,6 @@ const useAppState = () => {
 
       return draft;
     });
-
-    return id;
   };
 
   const addReceivedMessage = (from: string, content: string, verifiedStatus?: VerifiedStatus) => {
@@ -177,8 +175,8 @@ const useAppState = () => {
     const signature = verified && await signRequest(settings.httpEndpoint, headers)(message)
       .catch((err: any) => console.error('ERROR Failed to obtain signature', err));
     const encodedMessage = encodeMessage(myPeerId, message, signature);
-    const id = addSentMessage(myPeerId, destination, message);
-
+    const id = genId();
+    addSentMessage(myPeerId, destination, message, id);
     await sendMessage(settings.httpEndpoint, headers)(selection, encodedMessage, destination, id, updateMessage)
       .catch((err: any) => console.error('ERROR Failed to send message', err));
   };

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -199,7 +199,8 @@ const useAppState = () => {
         const { tag, from, message, signature } = decodeMessage(data.msg);
 
         const verifiedStatus : VerifiedStatus = signature ? 
-          (await verifySignatureFromPeerId(from, message, signature) ? 
+          // Messages are pre-pended with the padding to avoid generic signatures.
+          (await verifySignatureFromPeerId(from, `HOPR Signed Message: ${message}`, signature) ? 
             "VERIFIED" :
             "FAILED_VERIFICATION"
           ) :

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -34,6 +34,11 @@ export type Settings = {
   securityToken?: string;
 };
 
+export const DEFAULT_SETTINGS: Settings = {
+  httpEndpoint: "http://localhost:3001",
+  wsEndpoint: "ws://localhost:3000"
+}
+
 export type State = {
   settings: Settings;
   conversations: Map<string, Map<string, Message>>;
@@ -45,8 +50,8 @@ const useAppState = () => {
   const urlParams = !isSSR ? getUrlParams(location) : {};
   const [state, setState] = useImmer<State>({
     settings: {
-      httpEndpoint: urlParams.httpEndpoint || "http://localhost:3001",
-      wsEndpoint: urlParams.wsEndpoint || "ws://localhost:3000",
+      httpEndpoint: urlParams.httpEndpoint || DEFAULT_SETTINGS.httpEndpoint,
+      wsEndpoint: urlParams.wsEndpoint || DEFAULT_SETTINGS.wsEndpoint,
       securityToken: urlParams.securityToken,
     },
     verified: false,

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,4 +1,4 @@
-import { privKeyToPeerId, u8aToHex } from '@hoprnet/hopr-utils'
+import { privKeyToPeerId, u8aConcat, u8aToHex } from '@hoprnet/hopr-utils'
 import {
   encodeSignMessageRequest,
   decodeMessage,
@@ -9,6 +9,9 @@ import {
   encodeSignedRecipient,
   decodeSignedRecipient,
 } from "./utils";
+
+// see https://github.com/hoprnet/hoprnet/blob/master/packages/core/src/index.ts#L865-L870
+const HOPR_PREFIX = "HOPR Signed Message: ";
 
 test("isValidPeerId", () => {
   expect(
@@ -151,10 +154,44 @@ test("verifyAuthenticatedMessage:true", async () => {
   expect(await verifyAuthenticatedMessage(originalMessage, signedMessage, signer)).toEqual(true)
 })
 
-test("verifyAuthenticateMessage:true (from snapshot)", async() => {
-  const originalMessage = 'HOPR Signed Message: This should be working.'
+test("verifyAuthenticateMessage:true (from hopr-admin)", async() => {
+  const originalMessage = `${HOPR_PREFIX}This should be working.`
   const signer = '16Uiu2HAmN4enEu9822TMgG52goik85yEs4MqDdErtsGr8fy86VDQ'
   const signedMessage = '0x3045022100d9a8c2100ffa55aa5856889055bdf0e10f9831e2e695b3ad986c7692c5b9b35202201f00817c430bd72a2f64b92787f0a0947783d79fd9184d8031c998831c11c90d'
 
   expect(await verifyAuthenticatedMessage(originalMessage, signedMessage, signer)).toEqual(true)
+})
+
+test("verifyAuthenticateMessage:true (from myne-chat)", async () => {
+  const originalMessage = `${HOPR_PREFIX}This is a valid message.`
+  const signer = '16Uiu2HAm1fsKzaBjw8d4R8aQTRHRYM87LdBCtVEuMpgxs2CWv1Qk'
+  const signedMessage = '0x3044022018ba5a5e29e43e232f5b66235b56ba24598f11e68150c05c916ab0f96b5a959b02203b2fb23d8233787160753c0c8cc2fc459e5ef89137b8144cf5da018fd4d2580c'
+
+  expect(await verifyAuthenticatedMessage(originalMessage, signedMessage, signer)).toEqual(true)
+})
+
+test("verifyAuthenticateMessage:true (from api)", async() => {
+  const originalMessageInUa8 = u8aConcat(
+    new TextEncoder().encode(HOPR_PREFIX),
+    new Uint8Array([ // the message reads "This is a valid message."
+      84, 104, 105, 115,  32, 105, 115,
+      32,  97,  32, 118,  97, 108, 105,
+    100,  32, 109, 101, 115, 115,  97,
+    103, 101,  46
+  ])
+)
+ const originalMessage = new TextDecoder().decode(originalMessageInUa8)
+ const signer = '16Uiu2HAm1fsKzaBjw8d4R8aQTRHRYM87LdBCtVEuMpgxs2CWv1Qk'
+ const signedMessageInUa8 = new Uint8Array([ // the signature of the message "HOPR Signed Message: This is a valid message."
+  48, 68,   2,  32,  24, 186,  90,  94,  41, 228,  62,  35,
+  47, 91, 102,  35,  91,  86, 186,  36,  89, 143,  17, 230,
+ 129, 80, 192,  92, 145, 106, 176, 249, 107,  90, 149, 155,
+   2, 32,  59,  47, 178,  61, 130,  51, 120, 113,  96, 117,
+  60, 12, 140, 194, 252,  69, 158,  94, 248, 145,  55, 184,
+  20, 76, 245, 218,   1, 143, 212, 210,  88,  12
+])
+const signedMessage = u8aToHex(signedMessageInUa8) // We use u8aToHex as verifyAuthenticateMessage (arrayify) expects a `0x` based string
+console.log("ORIGINAL MESSAGE", originalMessage);
+console.log("SIGNED MESSAGE", signedMessage);
+expect(await verifyAuthenticatedMessage(originalMessage, signedMessage, signer)).toEqual(true)
 })

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -150,3 +150,11 @@ test("verifyAuthenticatedMessage:true", async () => {
   ))
   expect(await verifyAuthenticatedMessage(originalMessage, signedMessage, signer)).toEqual(true)
 })
+
+test("verifyAuthenticateMessage:true (from snapshot)", async() => {
+  const originalMessage = 'HOPR Signed Message: This should be working.'
+  const signer = '16Uiu2HAmN4enEu9822TMgG52goik85yEs4MqDdErtsGr8fy86VDQ'
+  const signedMessage = '0x3045022100d9a8c2100ffa55aa5856889055bdf0e10f9831e2e695b3ad986c7692c5b9b35202201f00817c430bd72a2f64b92787f0a0947783d79fd9184d8031c998831c11c90d'
+
+  expect(await verifyAuthenticatedMessage(originalMessage, signedMessage, signer)).toEqual(true)
+})


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1128312/150195346-45658f45-c7eb-4b20-8fd3-671ca53d2cd1.png)

Currently, messages aren't validated properly (as seen in the UI) since `handleReceiveMessages` doesn't read the signature and can't forward it to the proper internal callback. This PR solves this.

- Added tests to both `handleSendMessage` and `handleReceiveMessage` to avoid failing this in the future
- Implemented the actual verification in `handleReceiveMessage`
- Fixes #71
- Fixes #72 